### PR TITLE
Font improvements, shortcut to restart, quick tab switching

### DIFF
--- a/preditor/gui/command_palette/command_palette.py
+++ b/preditor/gui/command_palette/command_palette.py
@@ -27,7 +27,11 @@ class CommandPalette(QFrame):
         self.uiLineCOMPL.activated.connect(self.completed)
         self.uiLineCOMPL.highlighted.connect(self.completer_selected)
         # self.uiLineCOMPL.popup().clicked.connect(self.completed)
+        self.uiLineEDIT.textChanged.connect(self.update_completer)
         self.current_name = parent.name_for_workbox(parent.current_workbox())
+
+    def update_completer(self, wildcard):
+        self.uiLineCOMPL.updatePattern(wildcard)
 
     def completed(self, name):
         if isinstance(name, six.string_types):

--- a/preditor/gui/command_palette/command_palette.py
+++ b/preditor/gui/command_palette/command_palette.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+
+import six
+from Qt.QtCore import QPoint, Qt
+from Qt.QtWidgets import QFrame, QHBoxLayout, QLineEdit, QShortcut
+
+from .workbox_completer import WorkboxCompleter
+
+
+class CommandPalette(QFrame):
+    def __init__(self, model, parent=None, **kwargs):
+        super(CommandPalette, self).__init__(parent=parent, **kwargs)
+        self.y_offset = 100
+        lyt = QHBoxLayout(self)
+        self.uiLineEDIT = QLineEdit(parent=self)
+        lyt.addWidget(self.uiLineEDIT)
+        self.setMinimumSize(400, self.sizeHint().height())
+        self.uiCloseSCT = QShortcut(
+            Qt.Key_Escape, self, context=Qt.WidgetWithChildrenShortcut
+        )
+        self.uiCloseSCT.activated.connect(self.hide)
+        self.uiLineCOMPL = WorkboxCompleter()
+        self.uiLineCOMPL.split_char = None
+        self.uiLineCOMPL.setCaseSensitivity(False)
+        self.uiLineCOMPL.setModel(model)
+        self.uiLineEDIT.setCompleter(self.uiLineCOMPL)
+        self.uiLineCOMPL.activated.connect(self.completed)
+        self.uiLineCOMPL.highlighted.connect(self.completer_selected)
+        # self.uiLineCOMPL.popup().clicked.connect(self.completed)
+        self.current_name = parent.name_for_workbox(parent.current_workbox())
+
+    def completed(self, name):
+        if isinstance(name, six.string_types):
+            self.current_name = name
+        else:
+            self.current_name = self.uiLineCOMPL.pathFromIndex(name)
+        self.hide()
+
+    def completer_selected(self, name):
+        self.parent().workbox_for_name(name.rstrip("/"), visible=True)
+
+    def hide(self):
+        # Close the popup if its open
+        self.uiLineCOMPL.popup().hide()
+        # Restore the original tab as the user didn't choose the new tab
+        self.completer_selected(self.current_name)
+        super(CommandPalette, self).hide()
+
+    def reposition(self):
+        pgeo = self.parent().geometry()
+        geo = self.geometry()
+        center = QPoint(pgeo.width() // 2, self.y_offset)
+        geo.moveCenter(center)
+        self.setGeometry(geo)
+
+    def popup(self):
+        self.reposition()
+        self.uiLineEDIT.setFocus(Qt.PopupFocusReason)
+        self.show()
+        self.uiLineCOMPL.complete()

--- a/preditor/gui/command_palette/command_palette.py
+++ b/preditor/gui/command_palette/command_palette.py
@@ -1,64 +1,93 @@
 from __future__ import absolute_import
 
-import six
-from Qt.QtCore import QPoint, Qt
-from Qt.QtWidgets import QFrame, QHBoxLayout, QLineEdit, QShortcut
+from functools import partial
 
-from .workbox_completer import WorkboxCompleter
+from Qt.QtCore import QModelIndex, QPoint, Qt, Signal
+from Qt.QtWidgets import QFrame, QLineEdit, QListView, QShortcut, QVBoxLayout
+
+from .workbox_item_model import WorkboxFuzzyFilterProxyModel
 
 
 class CommandPalette(QFrame):
+    canceled = Signal("QModelIndex")
+    """Passes the original QModelIndex for the tab that was selected when the
+    widget was first shown. This lets you reset back to the orignal state."""
+    highlighted = Signal("QModelIndex")
+    """Emitted when the user navitages to the given index, but hasn't selected."""
+    selected = Signal("QModelIndex")
+    """Emitted when the user selects a item."""
+
     def __init__(self, model, parent=None, **kwargs):
         super(CommandPalette, self).__init__(parent=parent, **kwargs)
         self.y_offset = 100
-        lyt = QHBoxLayout(self)
-        self.uiLineEDIT = QLineEdit(parent=self)
-        lyt.addWidget(self.uiLineEDIT)
-        self.setMinimumSize(400, self.sizeHint().height())
+        self.setMinimumSize(400, 200)
         self.uiCloseSCT = QShortcut(
             Qt.Key_Escape, self, context=Qt.WidgetWithChildrenShortcut
         )
-        self.uiCloseSCT.activated.connect(self.hide)
-        self.uiLineCOMPL = WorkboxCompleter()
-        self.uiLineCOMPL.split_char = None
-        self.uiLineCOMPL.setCaseSensitivity(False)
-        self.uiLineCOMPL.setModel(model)
-        self.uiLineEDIT.setCompleter(self.uiLineCOMPL)
-        self.uiLineCOMPL.activated.connect(self.completed)
-        self.uiLineCOMPL.highlighted.connect(self.completer_selected)
-        # self.uiLineCOMPL.popup().clicked.connect(self.completed)
+        self.uiCloseSCT.activated.connect(self._canceled)
+
+        self.uiUpSCT = QShortcut(Qt.Key_Up, self, context=Qt.WidgetWithChildrenShortcut)
+        self.uiUpSCT.activated.connect(partial(self.increment_selection, -1))
+        self.uiDownSCT = QShortcut(
+            Qt.Key_Down, self, context=Qt.WidgetWithChildrenShortcut
+        )
+        self.uiDownSCT.activated.connect(partial(self.increment_selection, 1))
+
+        lyt = QVBoxLayout(self)
+        self.uiLineEDIT = QLineEdit(parent=self)
         self.uiLineEDIT.textChanged.connect(self.update_completer)
-        self.current_name = parent.name_for_workbox(parent.current_workbox())
+        self.uiLineEDIT.returnPressed.connect(self.activated)
+        lyt.addWidget(self.uiLineEDIT)
+        self.uiResultsLIST = QListView(self)
+        self.uiResultsLIST.activated.connect(self.activated)
+        self.proxy_model = WorkboxFuzzyFilterProxyModel(self)
+        self.proxy_model.setSourceModel(model)
+        self.uiResultsLIST.setModel(self.proxy_model)
+        lyt.addWidget(self.uiResultsLIST)
 
-    def update_completer(self, wildcard):
-        self.uiLineCOMPL.updatePattern(wildcard)
+        self.original_model_index = model.original_model_index
 
-    def completed(self, name):
-        if isinstance(name, six.string_types):
-            self.current_name = name
-        else:
-            self.current_name = self.uiLineCOMPL.pathFromIndex(name)
+    def activated(self):
+        current = self.uiResultsLIST.currentIndex()
+        self.selected.emit(current)
         self.hide()
 
-    def completer_selected(self, name):
-        self.parent().workbox_for_name(name.rstrip("/"), visible=True)
+    def increment_selection(self, direction):
+        current = self.uiResultsLIST.currentIndex()
+        col = 0
+        row = 0
+        if current.isValid():
+            col = current.column()
+            row = current.row() + direction
+        new = self.uiResultsLIST.model().index(row, col)
+        self.uiResultsLIST.setCurrentIndex(new)
+        self.highlighted.emit(new)
 
-    def hide(self):
-        # Close the popup if its open
-        self.uiLineCOMPL.popup().hide()
+    def update_completer(self, wildcard):
+        if wildcard:
+            if not self.uiResultsLIST.currentIndex().isValid():
+                new = self.uiResultsLIST.model().index(0, 0)
+                self.uiResultsLIST.setCurrentIndex(new)
+        else:
+            self.uiResultsLIST.clearSelection()
+            self.uiResultsLIST.setCurrentIndex(QModelIndex())
+        self.proxy_model.setFuzzySearch(wildcard)
+        self.highlighted.emit(self.uiResultsLIST.currentIndex())
+
+    def _canceled(self):
         # Restore the original tab as the user didn't choose the new tab
-        self.completer_selected(self.current_name)
-        super(CommandPalette, self).hide()
+        self.canceled.emit(self.original_model_index)
+        self.hide()
 
     def reposition(self):
         pgeo = self.parent().geometry()
         geo = self.geometry()
-        center = QPoint(pgeo.width() // 2, self.y_offset)
+        center = QPoint(pgeo.width() // 2, 0)
         geo.moveCenter(center)
+        geo.setY(self.y_offset)
         self.setGeometry(geo)
 
     def popup(self):
+        self.show()
         self.reposition()
         self.uiLineEDIT.setFocus(Qt.PopupFocusReason)
-        self.show()
-        self.uiLineCOMPL.complete()

--- a/preditor/gui/command_palette/workbox_completer.py
+++ b/preditor/gui/command_palette/workbox_completer.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from Qt.QtWidgets import QCompleter
+
+
+class WorkboxCompleter(QCompleter):
+    def __init__(self, *args, **kwargs):
+        super(WorkboxCompleter, self).__init__(*args, **kwargs)
+        # Set this to None to disable splitting of paths
+        self.split_char = "/"
+
+    def splitPath(self, path):
+        if self.split_char:
+            return path.split(self.split_char)
+        return [path]
+
+    def pathFromIndex(self, index):
+        return self.model().pathFromIndex(index)

--- a/preditor/gui/command_palette/workbox_completer.py
+++ b/preditor/gui/command_palette/workbox_completer.py
@@ -2,12 +2,23 @@ from __future__ import absolute_import
 
 from Qt.QtWidgets import QCompleter
 
+from .workbox_item_model import WorkboxFuzzyFilterProxyModel
+
 
 class WorkboxCompleter(QCompleter):
     def __init__(self, *args, **kwargs):
         super(WorkboxCompleter, self).__init__(*args, **kwargs)
         # Set this to None to disable splitting of paths
         self.split_char = "/"
+        # Create the proxy model that implemts fuzy searching
+        self.proxyModel = WorkboxFuzzyFilterProxyModel(self)
+        # Prevent the completer from removing results. This allows
+        # us to always see the filtered results from the proxy model.
+        self.setCompletionMode(self.UnfilteredPopupCompletion)
+
+    def setModel(self, model):
+        self.proxyModel.setSourceModel(model)
+        super().setModel(self.proxyModel)
 
     def splitPath(self, path):
         if self.split_char:
@@ -16,3 +27,7 @@ class WorkboxCompleter(QCompleter):
 
     def pathFromIndex(self, index):
         return self.model().pathFromIndex(index)
+        # return self.proxyModel.sourceModel().pathFromIndex(index)
+
+    def updatePattern(self, patternStr):
+        self.proxyModel.setFuzzySearch(patternStr)

--- a/preditor/gui/command_palette/workbox_item_model.py
+++ b/preditor/gui/command_palette/workbox_item_model.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+from Qt.QtCore import Qt
+from Qt.QtGui import QStandardItem, QStandardItemModel
+
+
+class WorkboxItemModel(QStandardItemModel):
+    def __init__(self, manager, *args, **kwargs):
+        super(WorkboxItemModel, self).__init__(*args, **kwargs)
+        self.manager = manager
+
+    def pathFromIndex(self, index):
+        parts = [""]
+        while index.isValid():
+            parts.append(self.data(index, Qt.DisplayRole))
+            index = index.parent()
+        if len(parts) == 1:
+            return ""
+        return "/".join([x for x in parts[::-1] if x])
+
+
+class WorkboxTreeItemModel(WorkboxItemModel):
+    def process(self):
+        root = self.invisibleRootItem()
+        prev_group = -1
+        for _, group_name, tab_name, group_index, _ in self.manager.all_widgets():
+            if prev_group != group_index:
+                group_item = QStandardItem(group_name)
+                root.appendRow(group_item)
+                prev_group = group_index
+
+            tab_item = QStandardItem(tab_name)
+            group_item.appendRow(tab_item)
+
+
+class WorkboxListItemModel(WorkboxItemModel):
+    def process(self):
+        root = self.invisibleRootItem()
+        for _, group_name, tab_name, _, _ in self.manager.all_widgets():
+            group_item = QStandardItem('/'.join((group_name, tab_name)))
+            root.appendRow(group_item)

--- a/preditor/gui/find_files.py
+++ b/preditor/gui/find_files.py
@@ -1,0 +1,154 @@
+from __future__ import print_function
+
+from collections import deque
+
+from Qt.QtWidgets import QWidget
+
+from ..gui import loadUi
+
+
+class FindFiles(QWidget):
+    def __init__(self, managers=None, parent=None):
+        super(FindFiles, self).__init__(parent=parent)
+        if managers is None:
+            managers = []
+        self.managers = managers
+
+        loadUi(__file__, self)
+
+    def insert_found_text(self, found_text, href, tool_tip):
+        cursor = self.console.textCursor()
+        # Insert hyperlink
+        fmt = cursor.charFormat()
+        fmt.setAnchor(True)
+        fmt.setAnchorHref(href)
+        fmt.setFontUnderline(True)
+        fmt.setToolTip(tool_tip)
+        cursor.insertText(found_text, fmt)
+
+    def insert_text(self, text):
+        cursor = self.console.textCursor()
+        fmt = cursor.charFormat()
+        fmt.setAnchor(False)
+        fmt.setAnchorHref('')
+        fmt.setFontUnderline(False)
+        fmt.setToolTip('')
+        cursor.insertText(text, fmt)
+
+    def indicate_results(
+        self,
+        line,
+        line_num,
+        find_text="undefined",
+        path="undefined",
+        workbox_id="undefined",
+        fmt="",
+    ):
+        href = '{}, {}, {}'.format(path, workbox_id, line_num)
+        tool_tip = "Open {} at line number {}".format(path, line_num)
+        find_len = len(find_text)
+
+        start = 0
+        line = fmt.format(
+            num=line_num, split=" " if line.find(find_text) == -1 else ":", line=line
+        )
+        end = line.find(find_text)
+        count = 0
+        while end != -1:
+            # insert prefix text
+            self.insert_text(line[start:end])
+            # insert indicated text preserving case
+            self.insert_found_text(line[end : end + find_len], href, tool_tip)
+            start = end + find_len
+            end = line.find(find_text, start)
+            count += 1
+            if count > 10:
+                print('break', start, end)
+                break
+        if end < find_len:
+            self.insert_text(line[start:])
+
+    def print_lines(self, start, *lines, info=None):
+        if info is None:
+            info = {}
+        info.setdefault("fmt", "  {num: 4d}{split} {line}")
+
+        # If start is negative, set it to zero
+        start = max(0, start)
+        for i, line in enumerate(lines):
+            # line = fmt.format(num=start + i, line=line)
+            # print(line)
+            self.indicate_results(line + "\n", start + i, **info)
+
+    def search_file_simple(self, editor, path, workbox_id):
+        # print('search_file_simple', path)
+        context = self.uiContextSPN.value()
+        find_text = self.uiFindTXT.text()
+        # Ensure the editor text is loaded
+        editor.__show__()
+        raw_lines = editor.__text__().splitlines()
+        # Add enough padding to cover the number of lines in the file
+        padding = len(str(len(raw_lines)))
+        fmt = "  {{num: >{}}}{{split}} {{line}}".format(padding)
+
+        # https://stackoverflow.com/a/52009859
+        pre_history = deque(maxlen=context)
+        post_history = None
+        post_line = None
+        first = True
+        for i, line in enumerate(raw_lines):
+            # Lines are 1 based indexes
+            i += 1
+            info = dict(find_text=find_text, fmt=fmt, path=path, workbox_id=workbox_id)
+            if find_text in line:
+                ii = i - context
+                if first:
+                    # Print the filename on the first find
+                    print("# File: {}".format(path))
+                    first = False
+                else:
+                    print(
+                        "  {dot: >{padding}} ".format(
+                            dot='.' * len(str(ii)), padding=padding
+                        )
+                    )
+                self.print_lines(ii, *pre_history, line, info=info)
+                # print(" xxx:", *pre_history, line, sep='')
+                # Clear history so if two errors seen in close proximity, we don't
+                # echo some lines twice
+                pre_history.clear()
+                # Start recording the post context
+                post_history = deque(maxlen=context)
+                post_line = i + 1
+            else:
+                # When deque reaches 25 lines, will automatically evict oldest
+                pre_history.append(line)
+                # Add the line to the post history after we find a result.
+                if post_history is not None:
+                    post_history.append(line)
+                    # Once we exceed context without finding another result,
+                    # print the post text and stop tracking post_history
+                    if len(post_history) >= context:
+                        self.print_lines(post_line, *post_history, info=info)
+                        post_history = None
+                        post_line = None
+
+        if post_history:
+            print('# --------')
+            self.print_lines(post_line, *post_history, info=info)
+
+    def find(self):
+        find_text = self.uiFindTXT.text()
+        print("Find:", find_text)
+
+        for manager in self.managers:
+            for (
+                editor,
+                group_name,
+                tab_name,
+                group_index,
+                tab_index,
+            ) in manager.all_widgets():
+                path = "/".join((group_name, tab_name))
+                workbox_id = '{},{}'.format(group_index, tab_index)
+                self.search_file_simple(editor, path, workbox_id)

--- a/preditor/gui/find_files.py
+++ b/preditor/gui/find_files.py
@@ -1,20 +1,32 @@
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from collections import deque
 
-from Qt.QtWidgets import QWidget
+from Qt.QtCore import Qt
+from Qt.QtWidgets import QApplication, QShortcut, QWidget
 
 from ..gui import loadUi
 
 
 class FindFiles(QWidget):
-    def __init__(self, managers=None, parent=None):
+    def __init__(self, parent=None, managers=None, console=None):
         super(FindFiles, self).__init__(parent=parent)
         if managers is None:
             managers = []
         self.managers = managers
+        self.console = console
 
         loadUi(__file__, self)
+
+        self.uiCloseSCT = QShortcut(
+            Qt.Key_Escape, self, context=Qt.WidgetWithChildrenShortcut
+        )
+        self.uiCloseSCT.activated.connect(self.hide)
+
+    def activate(self):
+        """Called to make this widget ready for the user to interact with."""
+        self.show()
+        self.uiFindTXT.setFocus()
 
     def insert_found_text(self, found_text, href, tool_tip):
         cursor = self.console.textCursor()
@@ -25,6 +37,8 @@ class FindFiles(QWidget):
         fmt.setFontUnderline(True)
         fmt.setToolTip(tool_tip)
         cursor.insertText(found_text, fmt)
+        # Show the updated text output
+        QApplication.instance().processEvents()
 
     def insert_text(self, text):
         cursor = self.console.textCursor()
@@ -34,6 +48,8 @@ class FindFiles(QWidget):
         fmt.setFontUnderline(False)
         fmt.setToolTip('')
         cursor.insertText(text, fmt)
+        # Show the updated text output
+        QApplication.instance().processEvents()
 
     def indicate_results(
         self,
@@ -44,7 +60,7 @@ class FindFiles(QWidget):
         workbox_id="undefined",
         fmt="",
     ):
-        href = '{}, {}, {}'.format(path, workbox_id, line_num)
+        href = ', {}, {}'.format(workbox_id, line_num)
         tool_tip = "Open {} at line number {}".format(path, line_num)
         find_len = len(find_text)
 

--- a/preditor/gui/group_tab_widget/__init__.py
+++ b/preditor/gui/group_tab_widget/__init__.py
@@ -114,11 +114,20 @@ class GroupTabWidget(OneTabWidget):
         return parent, editor
 
     def all_widgets(self):
-        """Returns every widget under every group."""
-        for i in range(self.count()):
-            tab_widget = self.widget(i)
-            for j in range(tab_widget.count()):
-                yield tab_widget.widget(j)
+        """A generator yielding information about every widget under every group.
+
+        Yields:
+            group tab name, widget tab name, group tab index, widget tab index, widget
+        """
+        for group_index in range(self.count()):
+            group_name = self.tabText(group_index)
+
+            tab_widget = self.widget(group_index)
+            for tab_index in range(tab_widget.count()):
+                tab_name = tab_widget.tabText(tab_index)
+                yield tab_widget.widget(
+                    tab_index
+                ), group_name, tab_name, group_index, tab_index
 
     def close_current_tab(self):
         """Convenient method to close the currently open editor tab prompting

--- a/preditor/gui/group_tab_widget/__init__.py
+++ b/preditor/gui/group_tab_widget/__init__.py
@@ -117,7 +117,7 @@ class GroupTabWidget(OneTabWidget):
         """A generator yielding information about every widget under every group.
 
         Yields:
-            group tab name, widget tab name, group tab index, widget tab index, widget
+            widget, group tab name, widget tab name, group tab index, widget tab index
         """
         for group_index in range(self.count()):
             group_name = self.tabText(group_index)

--- a/preditor/gui/loggerwindow.py
+++ b/preditor/gui/loggerwindow.py
@@ -1036,7 +1036,16 @@ class LoggerWindow(Window):
     def show_focus_name(self):
         model = WorkboxListItemModel(manager=self.uiWorkboxTAB)
         model.process()
+
+        def update_tab(index):
+            group, tab = model.workbox_indexes_from_model_index(index)
+            if group is not None:
+                self.uiWorkboxTAB.set_current_groups_from_index(group, tab)
+
         w = CommandPalette(model, parent=self)
+        w.selected.connect(update_tab)
+        w.canceled.connect(update_tab)
+        w.highlighted.connect(update_tab)
         w.popup()
 
     def updateCopyIndentsAsSpaces(self):

--- a/preditor/gui/loggerwindow.py
+++ b/preditor/gui/loggerwindow.py
@@ -106,6 +106,11 @@ class LoggerWindow(Window):
         )
         self.uiConsoleTOOLBAR.insertSeparator(self.uiRunSelectedACT)
 
+        # Configure Find in Workboxes
+        self.uiFindInWorkboxesWGT.hide()
+        self.uiFindInWorkboxesWGT.managers.append(self.uiWorkboxTAB)
+        self.uiFindInWorkboxesWGT.console = self.console()
+
         # Initial configuration of the logToFile feature
         self._logToFilePath = None
         self._stds = None
@@ -1021,6 +1026,11 @@ class LoggerWindow(Window):
     @Slot()
     def show_workbox_options(self):
         self.uiWorkboxSTACK.setCurrentIndex(WorkboxPages.Options)
+
+    @Slot()
+    def show_find_in_workboxes(self):
+        """Ensure the find workboxes widget is visible and has focus."""
+        self.uiFindInWorkboxesWGT.activate()
 
     @Slot()
     def show_focus_name(self):

--- a/preditor/gui/ui/find_files.ui
+++ b/preditor/gui/ui/find_files.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>636</width>
+    <height>41</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,13 +18,6 @@
     <widget class="QLabel" name="uiFindLBL">
      <property name="text">
       <string>Find:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QPushButton" name="uiFindBTN">
-     <property name="text">
-      <string>Find</string>
      </property>
     </widget>
    </item>
@@ -68,13 +61,18 @@
    <item row="0" column="2">
     <widget class="QLineEdit" name="uiFindTXT"/>
    </item>
-   <item row="1" column="0" colspan="4">
-    <widget class="QTreeWidget" name="uiResultsTREE">
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </column>
+   <item row="0" column="3">
+    <widget class="QPushButton" name="uiFindBTN">
+     <property name="text">
+      <string>Find</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QToolButton" name="uiCloseBTN">
+     <property name="text">
+      <string>x</string>
+     </property>
     </widget>
    </item>
   </layout>
@@ -88,12 +86,44 @@
    <slot>find()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>382</x>
-     <y>25</y>
+     <x>601</x>
+     <y>31</y>
     </hint>
     <hint type="destinationlabel">
      <x>421</x>
      <y>29</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>uiFindTXT</sender>
+   <signal>returnPressed()</signal>
+   <receiver>uiFindFilesWGT</receiver>
+   <slot>find()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>488</x>
+     <y>23</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>501</x>
+     <y>65</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>uiCloseBTN</sender>
+   <signal>released()</signal>
+   <receiver>uiFindFilesWGT</receiver>
+   <slot>hide()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>620</x>
+     <y>19</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>676</x>
+     <y>24</y>
     </hint>
    </hints>
   </connection>

--- a/preditor/gui/ui/find_files.ui
+++ b/preditor/gui/ui/find_files.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>uiFindFilesWGT</class>
+ <widget class="QWidget" name="uiFindFilesWGT">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QLabel" name="uiFindLBL">
+     <property name="text">
+      <string>Find:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QPushButton" name="uiFindBTN">
+     <property name="text">
+      <string>Find</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="uiFindOptionsLYT">
+     <item>
+      <widget class="QToolButton" name="uiRegexBTN">
+       <property name="toolTip">
+        <string>Regex</string>
+       </property>
+       <property name="text">
+        <string>Regex</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="uiCaseSensitiveBTN">
+       <property name="toolTip">
+        <string>Case Sensitive</string>
+       </property>
+       <property name="text">
+        <string>Case Sensitive</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="uiContextSPN">
+       <property name="toolTip">
+        <string>Context Lines</string>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::PlusMinus</enum>
+       </property>
+       <property name="value">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="uiFindTXT"/>
+   </item>
+   <item row="1" column="0" colspan="4">
+    <widget class="QTreeWidget" name="uiResultsTREE">
+     <column>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>uiFindBTN</sender>
+   <signal>released()</signal>
+   <receiver>uiFindFilesWGT</receiver>
+   <slot>find()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>382</x>
+     <y>25</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>421</x>
+     <y>29</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>find()</slot>
+ </slots>
+</ui>

--- a/preditor/gui/ui/loggerwindow.ui
+++ b/preditor/gui/ui/loggerwindow.ui
@@ -81,6 +81,9 @@
       </widget>
      </widget>
     </item>
+    <item>
+     <widget class="FindFiles" name="uiFindInWorkboxesWGT" native="true"/>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="uiMenuBar">
@@ -323,6 +326,8 @@
     <addaction name="menuFocus_to_Group"/>
     <addaction name="menuFocus_to_Tab"/>
     <addaction name="uiFocusNameACT"/>
+    <addaction name="separator"/>
+    <addaction name="uiFindInWorkboxesACT"/>
    </widget>
    <addaction name="uiScriptingMENU"/>
    <addaction name="menuEdit"/>
@@ -951,6 +956,14 @@ at the indicated line in the specified text editor.
     <string>Ctrl+Alt+Shift+R</string>
    </property>
   </action>
+  <action name="uiFindInWorkboxesACT">
+   <property name="text">
+    <string>Find in Workboxes</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+F</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -968,6 +981,12 @@ at the indicated line in the specified text editor.
    <class>EditorChooser</class>
    <extends>QWidget</extends>
    <header>preditor.gui.editor_chooser.h</header>
+  </customwidget>
+  <customwidget>
+   <class>FindFiles</class>
+   <extends>QWidget</extends>
+   <header>preditor.gui.find_files.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
@@ -1011,12 +1030,28 @@ at the indicated line in the specified text editor.
    <slot>update_workbox_stack()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>754</x>
-     <y>377</y>
+     <x>763</x>
+     <y>371</y>
     </hint>
     <hint type="destinationlabel">
      <x>747</x>
      <y>401</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>uiFindInWorkboxesACT</sender>
+   <signal>triggered()</signal>
+   <receiver>PrEditorWindow</receiver>
+   <slot>show_find_in_workboxes()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>202</y>
     </hint>
    </hints>
   </connection>
@@ -1026,5 +1061,6 @@ at the indicated line in the specified text editor.
   <slot>reset_options()</slot>
   <slot>show_workbox_options()</slot>
   <slot>update_workbox_stack()</slot>
+  <slot>show_find_in_workboxes()</slot>
  </slots>
 </ui>

--- a/preditor/gui/ui/loggerwindow.ui
+++ b/preditor/gui/ui/loggerwindow.ui
@@ -322,6 +322,7 @@
     <addaction name="separator"/>
     <addaction name="menuFocus_to_Group"/>
     <addaction name="menuFocus_to_Tab"/>
+    <addaction name="uiFocusNameACT"/>
    </widget>
    <addaction name="uiScriptingMENU"/>
    <addaction name="menuEdit"/>
@@ -929,6 +930,14 @@ at the indicated line in the specified text editor.
   <action name="uiBackupPreferencesACT">
    <property name="text">
     <string>Backup</string>
+   </property>
+  </action>
+  <action name="uiFocusNameACT">
+   <property name="text">
+    <string>Focus To Name</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
    </property>
   </action>
   <action name="uiRestartACT">

--- a/preditor/gui/workbox_mixin.py
+++ b/preditor/gui/workbox_mixin.py
@@ -24,6 +24,12 @@ class WorkboxMixin(object):
         self._tempfile = tempfile
         self.core_name = core_name
 
+        # Ensure the new instance's font settings match the rest of the app.
+        if "LoggerWindow" in str(type(self.window())):
+            font = self.window().font()
+            self.__set_margins_font__(font)
+            self.__set_font__(font)
+
     def __auto_complete_enabled__(self):
         raise NotImplementedError("Mixin method not overridden.")
 


### PR DESCRIPTION
- Fixes some in-consistencies with font resizing and saving
- Adds a Restart PrEditor action to the File menu. This allows for quickly restarting the standalone PrEditor python process. This allows for fully resetting the python instance easily. This option is hidden when PrEditor is not launched from the cli as it wont be able to exit the host application.
- Add a Command Palette that allows quickly switching between different workbox tabs similar to Sublime Text's Goto Anything feature. I would like to implement fuzzy search for this.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
