### PR TITLE
Restart PrEditor feature works when launched with `python -m`

### DIFF
--- a/preditor/gui/loggerwindow.py
+++ b/preditor/gui/loggerwindow.py
@@ -721,9 +721,15 @@ class LoggerWindow(Window):
         """
         self.close()
 
-        # Get the current command and launch it as a new process.
+        # Get the current command and launch it as a new process. This handles
+        # use of the preditor/preditor executable launchers.
         cmd = sys.argv[0]
         args = sys.argv[1:]
+
+        if os.path.basename(cmd) == "__main__.py":
+            # Handles using `python -m preditor` style launch.
+            cmd = sys.executable
+            args = ["-m", "preditor"] + args
         QtCore.QProcess.startDetached(cmd, args)
 
     def restorePrefs(self):


### PR DESCRIPTION
Restart feature now works when using `python -m preditor` as well as the preditor exe.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
