### PR TITLE
If stdout/stderr are null streams, don't forward data to them.

### DIFF
--- a/preditor/stream/director.py
+++ b/preditor/stream/director.py
@@ -54,6 +54,7 @@ class Director(io.TextIOBase):
             self.old_stream
             and not self.std_stream_wrapped
             and self.old_stream is not sys.__stdout__
+            and self.old_stream is not sys.__stderr__
         ):
             self.old_stream.close()
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes
On Windows if we're in pythonw.exe, then sys.stdout is a TextIOWrapper named "nul" that uses cp1252 encoding
If you try to write unicode characters to this stream, it will error out.
So if we find this "nul" named TextIOWrapper, we can just skip it since we don't have a cmd prompt window to print to anyway.

Also, when closing a Director, by default it closes the stream it wrapped.  If this previous stream happens to be the original `sys.__stdout__`, then we lose the ability to write anything to the console.
Even if the Director is wrapping something higher-level than the original `sys.__stdout__`, we shouldn't close any stream defined outside our nested Director systems since they may be in use elsewhere. So I added a check for that, along with a property to override that behavior if required.