### PR TITLE
QShortcut argument fix

### DIFF
--- a/preditor/gui/find_files.py
+++ b/preditor/gui/find_files.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 
 from Qt.QtCore import Qt
-from Qt.QtGui import QIcon
+from Qt.QtGui import QIcon, QKeySequence
 from Qt.QtWidgets import QApplication, QShortcut, QWidget
 
 from .. import resourcePath
@@ -30,17 +30,22 @@ class FindFiles(QWidget):
 
         # Create shortcuts
         self.uiCloseSCT = QShortcut(
-            Qt.Key_Escape, self, context=Qt.WidgetWithChildrenShortcut
+            QKeySequence(Qt.Key_Escape), self, context=Qt.WidgetWithChildrenShortcut
         )
+
         self.uiCloseSCT.activated.connect(self.hide)
 
         self.uiCaseSensitiveSCT = QShortcut(
-            Qt.AltModifier | Qt.Key_C, self, context=Qt.WidgetWithChildrenShortcut
+            QKeySequence(Qt.AltModifier | Qt.Key_C),
+            self,
+            context=Qt.WidgetWithChildrenShortcut,
         )
         self.uiCaseSensitiveSCT.activated.connect(self.uiCaseSensitiveBTN.toggle)
 
         self.uiRegexSCT = QShortcut(
-            Qt.AltModifier | Qt.Key_R, self, context=Qt.WidgetWithChildrenShortcut
+            QKeySequence(Qt.AltModifier | Qt.Key_R),
+            self,
+            context=Qt.WidgetWithChildrenShortcut,
         )
         self.uiRegexSCT.activated.connect(self.uiRegexBTN.toggle)
 


### PR DESCRIPTION
QShortcut requires QKeySequence as the first argument in PySide2

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes
In PySide2, the first argument to a QShortcut must be a QKeySequence. 
