### PR TITLE
Fix error when resizing font using scroll wheel in python 3.10+

### DIFF
--- a/preditor/gui/loggerwindow.py
+++ b/preditor/gui/loggerwindow.py
@@ -519,7 +519,7 @@ class LoggerWindow(Window):
                 delta = event.angleDelta().y()
 
             # convert delta to +1 or -1, depending
-            delta = delta / abs(delta)
+            delta = delta // abs(delta)
             minSize = 5
             maxSize = 50
             font = self.console().font()


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

The error being fixed:
```py
Traceback (most recent call last):
  File "C:\blur\dev\preditor\preditor\gui\console.py", line 197, in wheelEvent
    self.window().wheelEvent(event)
  File "C:\blur\dev\preditor\preditor\gui\loggerwindow.py", line 529, in wheelEvent
    self.setFontSize(newSize)
  File "C:\blur\dev\preditor\preditor\gui\loggerwindow.py", line 584, in setFontSize
    font.setPointSize(newSize)
TypeError: setPointSize(self, a0: int): argument 1 has unexpected type 'float'
```