### PR TITLE
Fix the maya module to point at the correct relative folder

### DIFF
--- a/preditor/dccs/maya/PrEditor_maya.mod
+++ b/preditor/dccs/maya/PrEditor_maya.mod
@@ -1,2 +1,2 @@
 + PrEditor DEVELOPMENT .
-PYTHONPATH +:= ../..
+PYTHONPATH +:= ../../..


### PR DESCRIPTION
The maya .mod file was pointing to the main preditor folder, and that was causing things like preditor/enum.py to load before the built in python enum.

It should go up one more level