### PR TITLE
Add ability to set console colors with style sheets

### DIFF
--- a/preditor/gui/codehighlighter.py
+++ b/preditor/gui/codehighlighter.py
@@ -35,15 +35,15 @@ class CodeHighlighter(QSyntaxHighlighter):
         # stylesheets
         parent = self.parent()
         if parent and hasattr(parent, 'commentColor'):
-            return parent.commentColor()
+            return parent.commentColor
         return self._commentColor
 
     def setCommentColor(self, color):
         # set the color for the parent if possible because this doesn't support
         # stylesheets
         parent = self.parent()
-        if parent and hasattr(parent, 'setCommentColor'):
-            parent.setCommentColor(color)
+        if parent and hasattr(parent, 'commentColor'):
+            parent.commentColor = color
         self._commentColor = color
 
     def commentFormat(self):
@@ -127,15 +127,15 @@ class CodeHighlighter(QSyntaxHighlighter):
         # stylesheets
         parent = self.parent()
         if parent and hasattr(parent, 'keywordColor'):
-            return parent.keywordColor()
+            return parent.keywordColor
         return self._keywordColor
 
     def setKeywordColor(self, color):
         # set the color for the parent if possible because this doesn't support
         # stylesheets
         parent = self.parent()
-        if parent and hasattr(parent, 'setKeywordColor'):
-            parent.setKeywordColor(color)
+        if parent and hasattr(parent, 'keywordColor'):
+            parent.keywordColor = color
         self._keywordColor = color
 
     def keywordFormat(self):
@@ -150,15 +150,15 @@ class CodeHighlighter(QSyntaxHighlighter):
         # stylesheets
         parent = self.parent()
         if parent and hasattr(parent, 'resultColor'):
-            return parent.resultColor()
+            return parent.resultColor
         return self._resultColor
 
     def setResultColor(self, color):
         # set the color for the parent if possible because this doesn't support
         # stylesheets
         parent = self.parent()
-        if parent and hasattr(parent, 'setResultColor'):
-            parent.setResultColor(color)
+        if parent and hasattr(parent, 'resultColor'):
+            parent.resultColor = color
         self._resultColor = color
 
     def resultFormat(self):
@@ -191,15 +191,15 @@ class CodeHighlighter(QSyntaxHighlighter):
         # stylesheets
         parent = self.parent()
         if parent and hasattr(parent, 'stringColor'):
-            return parent.stringColor()
+            return parent.stringColor
         return self._stringColor
 
     def setStringColor(self, color):
         # set the color for the parent if possible because this doesn't support
         # stylesheets
         parent = self.parent()
-        if parent and hasattr(parent, 'setStringColor'):
-            parent.setStringColor(color)
+        if parent and hasattr(parent, 'stringColor'):
+            parent.stringColor = color
         self._stringColor = color
 
     def stringFormat(self):

--- a/preditor/gui/console.py
+++ b/preditor/gui/console.py
@@ -20,6 +20,7 @@ from Qt.QtWidgets import QAbstractItemView, QAction, QApplication, QTextEdit
 
 from .. import debug, settings, stream
 from ..streamhandler_helper import StreamHandlerHelper
+from . import QtPropertyInit
 from .codehighlighter import CodeHighlighter
 from .completer import PythonCompleter
 from .suggest_path_quotes_dialog import SuggestPathQuotesDialog
@@ -28,8 +29,14 @@ from .suggest_path_quotes_dialog import SuggestPathQuotesDialog
 class ConsolePrEdit(QTextEdit):
     # Ensure the error prompt only shows up once.
     _errorPrompted = False
-    # the color error messages are displayed in, can be set by stylesheets
-    _errorMessageColor = QColor(Qt.red)
+
+    # These Qt Properties can be customized using style sheets.
+    commentColor = QtPropertyInit('_commentColor', QColor(0, 206, 52))
+    errorMessageColor = QtPropertyInit('_errorMessageColor', QColor(Qt.red))
+    keywordColor = QtPropertyInit('_keywordColor', QColor(17, 154, 255))
+    resultColor = QtPropertyInit('_resultColor', QColor(128, 128, 128))
+    stdoutColor = QtPropertyInit('_stdoutColor', QColor(17, 154, 255))
+    stringColor = QtPropertyInit('_stringColor', QColor(255, 128, 0))
 
     def __init__(self, parent):
         super(ConsolePrEdit, self).__init__(parent)
@@ -38,12 +45,6 @@ class ConsolePrEdit(QTextEdit):
 
         # If populated, also write to this interface
         self.outputPipe = None
-
-        self._stdoutColor = QColor(17, 154, 255)
-        self._commentColor = QColor(0, 206, 52)
-        self._keywordColor = QColor(17, 154, 255)
-        self._stringColor = QColor(255, 128, 0)
-        self._resultColor = QColor(128, 128, 128)
 
         self._consolePrompt = '>>> '
         # Note: Changing _outputPrompt may require updating resource\lang\python.xml
@@ -356,27 +357,9 @@ class ConsolePrEdit(QTextEdit):
         # Restore the cursor position to its original location
         self.setTextCursor(currentCursor)
 
-    def commentColor(self):
-        return self._commentColor
-
-    def setCommentColor(self, color):
-        self._commentColor = color
-
     def completer(self):
         """returns the completer instance that is associated with this editor"""
         return self._completer
-
-    def errorMessageColor(self):
-        return self.__class__._errorMessageColor
-
-    def setErrorMessageColor(self, color):
-        self.__class__._errorMessageColor = color
-
-    def foregroundColor(self):
-        return self._foregroundColor
-
-    def setForegroundColor(self, color):
-        self._foregroundColor = color
 
     def executeString(self, commandText, filename='<ConsolePrEdit>', extraPrint=True):
         if self.clearExecutionTime is not None:
@@ -687,12 +670,6 @@ class ConsolePrEdit(QTextEdit):
                         completer.wasCompletingCounter = 0
                         completer.wasCompleting = False
 
-    def keywordColor(self):
-        return self._keywordColor
-
-    def setKeywordColor(self, color):
-        self._keywordColor = color
-
     def moveToHome(self):
         """moves the cursor to the home location"""
         mode = QTextCursor.MoveAnchor
@@ -717,12 +694,6 @@ class ConsolePrEdit(QTextEdit):
 
     def prompt(self):
         return self._consolePrompt
-
-    def resultColor(self):
-        return self._resultColor
-
-    def setResultColor(self, color):
-        self._resultColor = color
 
     def setCompleter(self, completer):
         """sets the completer instance for this widget"""
@@ -773,18 +744,6 @@ class ConsolePrEdit(QTextEdit):
         """Create a new line to show output text."""
         self.startPrompt(self._outputPrompt)
 
-    def stdoutColor(self):
-        return self._stdoutColor
-
-    def setStdoutColor(self, color):
-        self._stdoutColor = color
-
-    def stringColor(self):
-        return self._stringColor
-
-    def setStringColor(self, color):
-        self._stringColor = color
-
     def removeCurrentLine(self):
         self.moveCursor(QTextCursor.End, QTextCursor.MoveAnchor)
         self.moveCursor(QTextCursor.StartOfLine, QTextCursor.MoveAnchor)
@@ -833,9 +792,9 @@ class ConsolePrEdit(QTextEdit):
 
             charFormat = QTextCharFormat()
             if not error:
-                charFormat.setForeground(self.stdoutColor())
+                charFormat.setForeground(self.stdoutColor)
             else:
-                charFormat.setForeground(self.errorMessageColor())
+                charFormat.setForeground(self.errorMessageColor)
             self.setCurrentCharFormat(charFormat)
 
             # If showing Error Hyperlinks... Sometimes (when a syntax error, at least),

--- a/preditor/gui/errordialog.py
+++ b/preditor/gui/errordialog.py
@@ -51,7 +51,7 @@ class ErrorDialog(Dialog):
             msg
             % {
                 'text': self.traceback_msg.split('\n')[-2],
-                'color': ConsolePrEdit._errorMessageColor.name(),
+                'color': ConsolePrEdit.errorMessageColor.name(),
             }
         )
 

--- a/preditor/resource/stylesheet/Bright.css
+++ b/preditor/resource/stylesheet/Bright.css
@@ -53,4 +53,10 @@ DocumentEditor {
 ConsolePrEdit{
 	color: rgb(0,0,0);
 	background-color: rgb(255,255,255);
+	qproperty-commentColor: rgb(0, 206, 52);
+	qproperty-errorMessageColor: rgb(255, 0, 0);
+	qproperty-keywordColor: rgb(17, 154, 255);
+	qproperty-resultColor: rgb(128, 128, 128);
+	qproperty-stdoutColor: rgb(17, 154, 255);
+	qproperty-stringColor: rgb(255, 128, 0);
 }

--- a/preditor/resource/stylesheet/Dark.css
+++ b/preditor/resource/stylesheet/Dark.css
@@ -187,4 +187,10 @@ DocumentEditor {
 ConsolePrEdit {
   color: rgb(255, 255, 255);
   background-color: rgb(70, 70, 73);
+  qproperty-commentColor: rgb(0, 206, 52);
+  qproperty-errorMessageColor: rgb(255, 0, 0);
+  qproperty-keywordColor: rgb(17, 154, 255);
+  qproperty-resultColor: rgb(128, 128, 128);
+  qproperty-stdoutColor: rgb(17, 154, 255);
+  qproperty-stringColor: rgb(255, 128, 0);
 }


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

Enable setting the error text using stylesheets.

```css
ConsolePrEdit{
	color: rgb(0,0,0);
	color: rgb(0,0,0);
	background-color: rgb(255,255,255);
	background-color: rgb(255,255,255);
	qproperty-commentColor: rgb(0, 206, 52);
	qproperty-errorMessageColor: rgb(255, 0, 0);
	qproperty-keywordColor: rgb(17, 154, 255);
	qproperty-resultColor: rgb(128, 128, 128);
	qproperty-stdoutColor: rgb(17, 154, 255);
	qproperty-stringColor: rgb(255, 128, 0);
}
```

It would probably be nice to apply replicate this for the other `ConsolePrEdit` color properties.