### PR TITLE
Fix getting errorMessageColor in ErrorDialog from previous commit

### DIFF
--- a/preditor/gui/errordialog.py
+++ b/preditor/gui/errordialog.py
@@ -5,16 +5,19 @@ import os
 import traceback
 
 from Qt.QtCore import Qt
-from Qt.QtGui import QPixmap
+from Qt.QtGui import QColor, QPixmap
 from Qt.QtWidgets import QDialog
 from redminelib.exceptions import ImpersonateError
 
 from .. import __file__ as pfile
-from . import Dialog, loadUi
+from . import Dialog, QtPropertyInit, loadUi
 from .redmine_login_dialog import RedmineLoginDialog
 
 
 class ErrorDialog(Dialog):
+    # These Qt Properties can be customized using style sheets.
+    errorMessageColor = QtPropertyInit('_errorMessageColor', QColor(Qt.GlobalColor.red))
+
     def __init__(self, parent):
         super(ErrorDialog, self).__init__(parent)
 
@@ -40,8 +43,6 @@ class ErrorDialog(Dialog):
         self.ignoreButton.clicked.connect(self.close)
 
     def setText(self, exc_info):
-        from .console import ConsolePrEdit
-
         self.traceback_msg = "".join(traceback.format_exception(*exc_info))
         msg = (
             'The following error has occurred:<br>'
@@ -51,7 +52,7 @@ class ErrorDialog(Dialog):
             msg
             % {
                 'text': self.traceback_msg.split('\n')[-2],
-                'color': ConsolePrEdit.errorMessageColor.name(),
+                'color': self.errorMessageColor.name(),
             }
         )
 

--- a/preditor/resource/stylesheet/Bright.css
+++ b/preditor/resource/stylesheet/Bright.css
@@ -50,11 +50,14 @@ DocumentEditor {
 	qproperty-paperDecorator: "white";
 }
 
-ConsolePrEdit{
+ConsolePrEdit, ErrorDialog {
+	qproperty-errorMessageColor: rgb(255, 0, 0);
+}
+
+ConsolePrEdit {
 	color: rgb(0,0,0);
 	background-color: rgb(255,255,255);
 	qproperty-commentColor: rgb(0, 206, 52);
-	qproperty-errorMessageColor: rgb(255, 0, 0);
 	qproperty-keywordColor: rgb(17, 154, 255);
 	qproperty-resultColor: rgb(128, 128, 128);
 	qproperty-stdoutColor: rgb(17, 154, 255);

--- a/preditor/resource/stylesheet/Dark.css
+++ b/preditor/resource/stylesheet/Dark.css
@@ -184,11 +184,14 @@ DocumentEditor {
 }
 
 
+ConsolePrEdit, ErrorDialog {
+  qproperty-errorMessageColor: rgb(255, 0, 0);
+}
+
 ConsolePrEdit {
   color: rgb(255, 255, 255);
   background-color: rgb(70, 70, 73);
   qproperty-commentColor: rgb(0, 206, 52);
-  qproperty-errorMessageColor: rgb(255, 0, 0);
   qproperty-keywordColor: rgb(17, 154, 255);
   qproperty-resultColor: rgb(128, 128, 128);
   qproperty-stdoutColor: rgb(17, 154, 255);


### PR DESCRIPTION
Fixes bugs with the previous commit only found when causing the ErrorDialog to run.

The value of a pyqtProperty(PySideX untested) are only accessible from instances, not class properties. Even if this wasn't the case, it likely would only get set to the style sheet setting when initialized as well.

The ErrorDialog now has its own Property that is styled the same by default.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
