### PR TITLE
Release action now uses the same build command as the preview build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: PyPi Release
 
 on:
   release:
@@ -23,11 +23,22 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools wheel twine
+          python -m pip install --upgrade build setuptools wheel twine
 
       - name: Build wheel
         run: |
-          python setup.py build bdist_wheel
+          python -m build --wheel --sdist
+
+      # Upload the built pip packages so we can inspect them
+      - name: Upload packages.
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-packages
+          path: |
+            dist/preditor-*.whl
+            dist/preditor-*.tar.gz
+          # This is only used if there is a problem with the next step
+          retention-days: 1
 
       - name: Publish to PyPI
         env:


### PR DESCRIPTION
The 0.7.0 release failed because this was using the old setup.py method. It didn't generate the preditor/version.py file which broke that release. The merge request preview builds were using build and generated correctly.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
