### PR TITLE
Show if a logger is disabled, and prevent logging_config from disabling loggers.

### DIFF
--- a/preditor/gui/level_buttons.py
+++ b/preditor/gui/level_buttons.py
@@ -291,6 +291,21 @@ class LoggingLevelMenu(LazyMenu):
         self.addMenu(HandlerMenu(self.logger, self))
         self.addSeparator()
 
+        if self.logger.disabled:
+            # Warn the user that this logger has been disabled. The documentation
+            # says to consider this property as read only so this is just info
+            # and does not implement a way to re-enable this logger. It's not
+            # disabled because that would prevent the tooltip from showing.
+            action = self.addAction("Logger is disabled")
+            action.setToolTip(
+                'This <b>logger has been disabled</b> and does not handle events '
+                "so you likely won't see events from it or its children. "
+                'This normally happens when using logging.config with '
+                '"disable_existing_loggers" defaulted to True.'
+            )
+            action.setIcon(QIcon(resourcePath('img/warning-big.png')))
+            self.addSeparator()
+
         for logger_level in LoggerLevels:
             is_current = logger_level.is_current(self.logger)
 

--- a/preditor/logging_config.py
+++ b/preditor/logging_config.py
@@ -9,9 +9,12 @@ from .prefs import prefs_path
 
 
 class LoggingConfig(object):
-    def __init__(self, core_name, version=1):
+    def __init__(self, core_name, version=1, disable_existing_loggers=False):
         self._filename = None
-        self.cfg = {'version': version}
+        self.cfg = {
+            'version': version,
+            'disable_existing_loggers': disable_existing_loggers,
+        }
         self.core_name = core_name
 
     def add_logger(self, name, logger):


### PR DESCRIPTION
<img width="369" height="233" alt="pythonw_UuUt7LNCxz" src="https://github.com/user-attachments/assets/72fe5caa-8f4b-4cfc-b595-5478bd24fa6e" />

`logging_config` now adds `disable_existing_loggers=False` to the logging config dictionary. This prevents logging.config from disabling previous loggers which is not what we want to happen. [See Warning](https://docs.python.org/3/howto/logging.html#configuring-logging).

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
