### PR TITLE
Fix extra \r added to newlines on windows for old_stream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -31,7 +31,7 @@ jobs:
 
       # Upload the built pip packages so we can inspect them
       - name: Upload packages.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pip-packages
           path: |

--- a/.github/workflows/static-analysis-and-test.yml
+++ b/.github/workflows/static-analysis-and-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -77,7 +77,7 @@ jobs:
           tox -e begin,py -- --tb short
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.python }}
           path: .coverage/*
@@ -97,10 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -115,7 +115,7 @@ jobs:
           tox -e begin
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: .coverage/
           pattern: coverage-*
@@ -136,7 +136,7 @@ jobs:
           # python -m coverage report --fail-under=100
 
       - name: Upload HTML report if check failed.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: html-report
           path: htmlcov
@@ -160,12 +160,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -179,7 +179,7 @@ jobs:
           python -m build --wheel --sdist
 
       - name: Upload packages.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pip-packages
           path: |

--- a/README.md
+++ b/README.md
@@ -216,6 +216,37 @@ or add menu items. When using this plugin, make sure to use the
 to the LoggingLevelButton's handlers sub-menus. This allows you to install a
 handler instance on a specific logging object.
 
+# Testing
+
+We use [tox](https://tox.wiki/) to run tests across multiple python versions and to run
+linting/formatting checks. This ensures that the code works correctly across all
+supported versions of python.
+
+While you can run `pytest` directly, using `tox` is recommended as it ensures all
+dependencies are correctly installed and runs the full suite of checks.
+
+To run all tests and checks:
+```batch
+tox
+```
+
+You can speed up testing by `-p` to make the tests run in parallel.
+
+To run only a specific environment (e.g., python 3.11):
+```batch
+tox -e py311
+```
+
+To run a specific test file or pass arguments to pytest, use `--`:
+```batch
+tox -e py311 -- tests/test_stream.py
+```
+
+To run only the linting checks:
+```batch
+tox -e black,flake8,deptry
+```
+
 # Qt Designer integration
 
 PrEditor includes some reusable widgets that are useful to integrate into your

--- a/preditor/stream/director.py
+++ b/preditor/stream/director.py
@@ -104,6 +104,10 @@ class Director(io.TextIOWrapper):
         raw = _DirectorBuffer(manager, state, old_stream, name)
         buffer = io.BufferedWriter(raw)
 
+        # Disable newline translation in this TextIOWrapper so that it doesn't
+        # double up on Windows (where the old_stream will likely also do translation)
+        kwargs.setdefault("newline", "")
+
         super().__init__(buffer, encoding="utf-8", write_through=True, *args, **kwargs)
 
     def __repr__(self):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -8,7 +8,7 @@ from logging import NOTSET
 
 import pytest
 
-from preditor import utils
+from preditor import settings, utils
 from preditor.constants import StreamType
 from preditor.stream import Director, Manager, install_to_std
 
@@ -371,3 +371,32 @@ class TestShellPrint:
                     "",
                 ]
             )
+
+
+def test_newline_translation(manager):
+    """Verify that Director doesn't perform redundant newline translation.
+    On Windows, TextIOWrapper(newline=None) translates \n to \r\n.
+    Director should NOT translate \n, leaving it to the underlying stream.
+    """
+    # Simulate a stream that performs translation (like sys.stdout on Windows)
+    buf = io.BytesIO()
+    underlying_stream = io.TextIOWrapper(buf, encoding="utf-8", newline=None)
+
+    director = Director(manager, "test_out", old_stream=underlying_stream)
+
+    # Write a string with a newline
+    director.write("Line 1\nLine 2\n")
+    director.flush()
+    underlying_stream.flush()
+
+    result = buf.getvalue()
+
+    # The result should contain exactly one `\r` per `\n`. If translation was
+    # redundant, we'd see `\r\r\n` but only on windows.
+    assert b"\r\r\n" not in result
+    if settings.OS_TYPE == 'Windows':
+        assert b"\r\n" in result
+        assert result == b"Line 1\r\nLine 2\r\n"
+    else:
+        assert b"\r\n" not in result
+        assert result == b"Line 1\nLine 2\n"


### PR DESCRIPTION
The newer `io.TextIOWrapper` implementation was leading to `\r\n` having `\n` replaced with `\r\n` on windows leading to `\r\r\n` newlines. This is not visible in PrEditor's console but in stdout/err.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)