### PR TITLE
Fix crash showing PrEditor in Houdini 21.0

### DIFF
--- a/preditor/gui/console_base.py
+++ b/preditor/gui/console_base.py
@@ -8,7 +8,7 @@ from fractions import Fraction
 from typing import Optional
 
 from Qt import QtCompat
-from Qt.QtCore import Property, Qt
+from Qt.QtCore import Property, Qt, QTimer
 from Qt.QtGui import (
     QColor,
     QFontMetrics,
@@ -514,8 +514,10 @@ class ConsoleBase(QTextEdit):
         if not self._first_show:
             return False
 
-        # Configure the stream callbacks if enabled
-        self.update_streams()
+        # Configure the stream callbacks if enabled. Delay calling these until
+        # the UI has been fully shown. This is prevents some DCC's like
+        # Houdini 21.0(possibly Qt6) from segfaulting.
+        QTimer.singleShot(0, self.update_streams)
 
         # Redefine highlight variables now that stylesheet may have been updated
         self.codeHighlighter().defineHighlightVariables()


### PR DESCRIPTION
Using a houdini menu to launch PrEditor would cause houdini to segfault. This prevents that by delaying the replay of previous prints to after the logger window is shown.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)