### PR TITLE
Replace uses of `exec_` with `exec`

### DIFF
--- a/examples/add_to_app.py
+++ b/examples/add_to_app.py
@@ -69,4 +69,4 @@ if __name__ == '__main__':
     act.triggered.connect(raise_error)
 
     main_gui.show()
-    app.exec_()
+    app.exec()

--- a/examples/output_console.py
+++ b/examples/output_console.py
@@ -240,4 +240,4 @@ if __name__ == '__main__':
     main_gui = ExampleApp(init_preditor=not args.no_preditor)
 
     main_gui.show()
-    app.exec_()
+    app.exec()

--- a/preditor/excepthooks.py
+++ b/preditor/excepthooks.py
@@ -137,7 +137,7 @@ class PreditorExceptHook(object):
             ConsolePrEdit._errorPrompted = True
             errorDialog = config.error_dialog_class(config.root_window())
             errorDialog.setText(exc_info)
-            errorDialog.exec_()
+            errorDialog.exec()
 
         # interrupted until dialog closed
         finally:

--- a/preditor/gui/app.py
+++ b/preditor/gui/app.py
@@ -160,4 +160,4 @@ class App(object):
         """Exec's the QApplication if it hasn't already been started."""
         if self.app_created and self.app and not self.app_has_exec:
             self.app_has_exec = True
-            Qt.QtCompat.QApplication.exec_()
+            Qt.QtCompat.QApplication.exec()


### PR DESCRIPTION
Qt6 has retired the python 2 workaround now that `exec` is not reserved. PyQt6 no longer supports `exec_` and Qt5 already supported `exec` in py3. This covers the remaining uses of `exec_`, several others were already updated.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
