### PR TITLE
event.pos() was deprecated and removed

### DIFF
--- a/preditor/gui/console_base.py
+++ b/preditor/gui/console_base.py
@@ -18,6 +18,7 @@ from Qt.QtGui import (
     QTextCursor,
 )
 from Qt.QtWidgets import QAction, QApplication, QTextEdit, QWidget
+from Qt.QtCompat import QMouseEvent
 
 from .. import instance, resourcePath, stream
 from ..constants import StreamType
@@ -136,6 +137,7 @@ class ConsoleBase(QTextEdit):
     def contextMenuEvent(self, event):
         """Builds a custom right click menu to show."""
         # Create the standard menu and allow subclasses to customize it
+        # The event.pos method for QContextMenuEvent was NOT removed
         menu = self.createStandardContextMenu(event.pos())
         menu = self.update_context_menu(menu)
         if self.controller:
@@ -432,7 +434,8 @@ class ConsoleBase(QTextEdit):
         """Overload of mousePressEvent to change mouse pointer to indicate it is
         over a clickable error hyperlink.
         """
-        if self.anchorAt(event.pos()):
+        pos = QMouseEvent.position(event).toPoint()
+        if self.anchorAt(pos):
             self.viewport().setCursor(Qt.CursorShape.PointingHandCursor)
         else:
             self.viewport().unsetCursor()
@@ -444,8 +447,9 @@ class ConsoleBase(QTextEdit):
         select text), we check if user clicked an error hyperlink.
         """
         left = event.button() == Qt.MouseButton.LeftButton
-        anchor = self.anchorAt(event.pos())
-        self.mousePressPos = event.pos()
+        pos = QMouseEvent.position(event).toPoint()
+        anchor = self.anchorAt(pos)
+        self.mousePressPos = pos
 
         if left and anchor:
             event.ignore()
@@ -457,9 +461,10 @@ class ConsoleBase(QTextEdit):
         """Overload of mouseReleaseEvent to capture if user has left clicked... Check if
         click position is the same as release position, if so, call errorHyperlink.
         """
-        samePos = event.pos() == self.mousePressPos
+        pos = QMouseEvent.position(event).toPoint()
+        samePos = pos == self.mousePressPos
         left = event.button() == Qt.MouseButton.LeftButton
-        anchor = self.anchorAt(event.pos())
+        anchor = self.anchorAt(pos)
 
         if samePos and left and anchor:
             self.errorHyperlink(anchor)

--- a/preditor/gui/drag_tab_bar.py
+++ b/preditor/gui/drag_tab_bar.py
@@ -14,6 +14,7 @@ from Qt.QtWidgets import (
     QSizePolicy,
     QTabBar,
 )
+from Qt.QtCompat import QMouseEvent, QDragMoveEvent
 
 from preditor import osystem
 
@@ -236,7 +237,8 @@ class DragTabBar(QTabBar):
 
         # Check if the mouse has moved outside of the widget, if not, let
         # the QTabBar handle the internal tab movement.
-        event_pos = event.pos()
+
+        event_pos = QMouseEvent.position(event).toPoint()
         global_pos = self.mapToGlobal(event_pos)
         bar_geo = QRect(self.mapToGlobal(self.pos()), self.size())
         inside = bar_geo.contains(global_pos)
@@ -268,7 +270,8 @@ class DragTabBar(QTabBar):
 
     def mousePressEvent(self, event):  # noqa: N802
         if event.button() == Qt.MouseButton.LeftButton and not self._mime_data:
-            tab_index = self.tabAt(event.pos())
+            pos = QMouseEvent.position(event).toPoint()
+            tab_index = self.tabAt(pos)
 
             # While we don't remove the tab on mouse press, capture its tab image
             # and attach it to the mouse. This also stores info needed to handle
@@ -312,7 +315,8 @@ class DragTabBar(QTabBar):
         # the current tab so users can easily drop inside that tab.
         if not event.mimeData().hasFormat(self.mime_type):
             event.accept()
-            tab_index = self.tabAt(event.pos())
+            pos = QDragMoveEvent().position(event).toPoint()
+            tab_index = self.tabAt(pos)
             if tab_index == -1:
                 tab_index = self.count() - 1
             if self.currentIndex() != tab_index:


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://github.com/PyCQA/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

Use the Qt.QtCompat module to update the event position getters.